### PR TITLE
Update libraries to modern versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # hapi-oauth2-server-plugin [![Build Status](https://travis-ci.org/getapper/hapi-oauth-2-server.svg?branch=master)](https://travis-ci.org/getapper/hapi-oauth-2-server)
 
-
 Complete, compliant and well tested module for implementing an OAuth2 Server/Provider with [hapi](https://github.com/hapijs/hapi) in [node.js](http://nodejs.org/).
 
-This is the hapi wrapper for [oauth2-server](https://github.com/oauthjs/node-oauth2-server).
+This is the hapi wrapper for [@node-oauth/oauth2-server](https://github.com/node-oauth/node-oauth2-server).
 
 ## Installation
 
@@ -90,4 +89,4 @@ The repository offers also an out-of-the-box example and unit tests inside the `
 
 ## What's next
 
-Starting from this you can adapt it to your current authentication and authorization Hapi plugin or create your own by wrapping it as well in a new one. 
+Starting from this you can adapt it to your current authentication and authorization Hapi plugin or create your own by wrapping it as well in a new one.

--- a/index.js
+++ b/index.js
@@ -1,10 +1,14 @@
+// import Joi from 'joi'
+// import * as OAuth2Server from '@node-oauth/oauth2-server'
+// import { Request, Response } from '@node-oauth/oauth2-server'
+
 const Joi = require('joi')
-const OAuth2Server = require('oauth2-server')
-const Request = require('oauth2-server').Request
-const Response = require('oauth2-server').Response
+const OAuth2Server = require('@node-oauth/oauth2-server')
+const { Request, Response } = require('@node-oauth/oauth2-server')
 
 const fromHapiReq = req => {
   const { method, payload, ...other } = req
+  // console.log('other: ', other)
   return new Request({
     method: method.toUpperCase(),
     body: payload,
@@ -15,9 +19,14 @@ const fromHapiReq = req => {
 exports.plugin = {
   pkg: require('./package.json'),
   register: async function (server, options) {
-    await Joi.validate(options, Joi.object().keys({
+    const schema = Joi.object().keys({
       model: Joi.object().required()
-    }))
+    })
+
+    const { error } = schema.validate(options)
+    if (error) {
+      throw error
+    }
 
     const oauthServer = new OAuth2Server(options)
 

--- a/index.js
+++ b/index.js
@@ -1,14 +1,9 @@
-// import Joi from 'joi'
-// import * as OAuth2Server from '@node-oauth/oauth2-server'
-// import { Request, Response } from '@node-oauth/oauth2-server'
-
 const Joi = require('joi')
 const OAuth2Server = require('@node-oauth/oauth2-server')
 const { Request, Response } = require('@node-oauth/oauth2-server')
 
 const fromHapiReq = req => {
   const { method, payload, ...other } = req
-  // console.log('other: ', other)
   return new Request({
     method: method.toUpperCase(),
     body: payload,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@goaldsports/hapi-oauth2-server-plugin",
+  "name": "hapi-oauth2-server-plugin",
   "version": "0.5.0",
   "description": "Hapijs wrapper for node oauth2-server package",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "hapi-oauth2-server-plugin",
-  "version": "0.4.0",
+  "name": "@goaldsports/hapi-oauth2-server-plugin",
+  "version": "0.5.0",
   "description": "Hapijs wrapper for node oauth2-server package",
   "main": "index.js",
   "scripts": {
@@ -24,16 +24,13 @@
   },
   "homepage": "https://github.com/getapper/hapi-oauth-2-server#readme",
   "devDependencies": {
-    "code": "5.2.4",
-    "hapi": "17.8.4",
-    "lab": "18.0.2",
-    "moment": "2.24.0"
-  },
-  "peerDependencies": {
-    "hapi": "^17.0.0"
+    "@hapi/code": "9.0.3",
+    "@hapi/hapi": "21.3.12",
+    "@hapi/lab": "26.0.0",
+    "moment": "2.30.1"
   },
   "dependencies": {
-    "joi": "14.3.1",
-    "oauth2-server": "3.0.1"
+    "@node-oauth/oauth2-server": "5.2.0",
+    "joi": "17.13.3"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,13 +1,14 @@
-const build = require('./server')
-const model = require('./model')
-const code = require('code')
-const labLib = require('lab')
+// import { build } from './server.js'
+// import { model } from './model.js'
+// import { expect } from '@hapi/code'
+// import * as lab from '@hapi/lab';
 
-const lab = (exports.lab = labLib.script())
-const describe = lab.describe
-const before = lab.before
-const it = lab.it
-const expect = code.expect
+const { expect } = require('@hapi/code')
+const Lab = require('@hapi/lab')
+const { model } = require('./model')
+const { build } = require('./server')
+
+const { describe, before, it } = exports.lab = Lab.script()
 
 describe('Hapi oauth2 server', () => {
   let server

--- a/test/index.js
+++ b/test/index.js
@@ -1,8 +1,3 @@
-// import { build } from './server.js'
-// import { model } from './model.js'
-// import { expect } from '@hapi/code'
-// import * as lab from '@hapi/lab';
-
 const { expect } = require('@hapi/code')
 const Lab = require('@hapi/lab')
 const { model } = require('./model')

--- a/test/model.js
+++ b/test/model.js
@@ -1,4 +1,3 @@
-// import moment from 'moment';
 const moment = require('moment');
 
 exports.model = {

--- a/test/model.js
+++ b/test/model.js
@@ -1,6 +1,7 @@
-const moment = require('moment')
+// import moment from 'moment';
+const moment = require('moment');
 
-module.exports = {
+exports.model = {
   getAccessToken: async () => {
     return { user: {}, accessTokenExpiresAt: moment().add(3, 'days').toDate() }
   },
@@ -8,7 +9,7 @@ module.exports = {
     return {
       code: 'be6e365e9f29c19e631078e8e376326bdf086576',
       expiresAt: moment().add(3, 'days').toDate(),
-      scope: 'test',
+      scope: ['test'],
       client: { id: 'test' },
       user: {}
     };

--- a/test/server.js
+++ b/test/server.js
@@ -1,8 +1,11 @@
-const Hapi = require('hapi')
-const HapiOAuth2Server = require('../')
+// import { Server } from '@hapi/hapi'
+// import * as HapiOAuth2Server from '../index.js'
 
-module.exports = async model => {
-  const server = Hapi.server({
+const { Server } = require('@hapi/hapi')
+const HapiOAuth2Server = require('../index.js')
+
+exports.build = async model => {
+  const server = Server({
     port: 3000,
     host: 'localhost'
   })

--- a/test/server.js
+++ b/test/server.js
@@ -1,6 +1,3 @@
-// import { Server } from '@hapi/hapi'
-// import * as HapiOAuth2Server from '../index.js'
-
 const { Server } = require('@hapi/hapi')
 const HapiOAuth2Server = require('../index.js')
 


### PR DESCRIPTION
Updated OAuth2 server to ([@node-oauth/oauth2-server](https://github.com/node-oauth/node-oauth2-server)) as it seems better supported than the previous server. (Or at least, more recently updated)

Update the Hapi components to more recent versions.

Updated the code and tests to match these newer library versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes v0.5.0

- **Dependencies**
  - Updated OAuth2 server library to `@node-oauth/oauth2-server`
  - Upgraded Hapi and testing dependencies to latest versions
  - Updated Joi validation library

- **Breaking Changes**
  - Migrated from `oauth2-server` to `@node-oauth/oauth2-server`
  - Modified module export structures in test files
  - Changed `scope` property type in authorization code

- **Improvements**
  - Enhanced validation logic for OAuth configuration
  - Modernized testing framework imports
  - Improved package compatibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->